### PR TITLE
Fix case-sensitive column handling in NAAIM fetcher

### DIFF
--- a/fetchers/naaim.py
+++ b/fetchers/naaim.py
@@ -14,11 +14,8 @@ def main():
     if txt:
         df = safe_read_csv_text(txt)
         if df is not None:
-            # 标准化两列
-            cols = [c.lower() for c in df.columns]
-            if "date" not in cols or ("value" not in cols and "exposure" not in cols):
-                # 兼容官方 csv 的列名大小写
-                df.columns = [c.lower() for c in df.columns]
+            # Always normalize column names to lowercase to handle case variations
+            df.columns = [c.lower() for c in df.columns]
             if "value" not in df.columns and "exposure" in df.columns:
                 df["value"] = df["exposure"]
             if "date" in df.columns and "value" in df.columns:

--- a/tests/test_naaim_fetcher.py
+++ b/tests/test_naaim_fetcher.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import fetchers.naaim as naaim
+
+
+def test_naaim_handles_uppercase_columns(tmp_path, monkeypatch):
+    csv_text = "Date,Exposure\n2024-01-01,100\n2024-01-02,110\n"
+    monkeypatch.setattr(naaim, "get_text_with_fallbacks", lambda urls, timeout=30: csv_text)
+    monkeypatch.setattr(naaim, "load_prev_csv", lambda path: None)
+    out_path = tmp_path / "naaim_exposure.csv"
+    monkeypatch.setattr(naaim, "OUT_CSV", str(out_path))
+    naaim.main()
+    df = pd.read_csv(out_path)
+    assert list(df.columns) == ["date", "value"]
+    assert len(df) == 2


### PR DESCRIPTION
## Summary
- Normalize NAAIM CSV columns to lowercase before processing to handle case variations
- Add regression test ensuring uppercase headers are processed correctly

## Testing
- `python -m py_compile fetchers/naaim.py tests/test_naaim_fetcher.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898ae82d654833391864b5eda1c0072