### PR TITLE
fix(app): auto-detect base path for JSON URLs (GitHub Pages)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <base href="/anxiousmonkey-backtests/">
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Anxious Monkey – Live Alpha App (revamped)</title>

--- a/docs/app/index.html
+++ b/docs/app/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <base href="/anxiousmonkey-backtests/">
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Anxious Monkey – Live Alpha App (revamped)</title>


### PR DESCRIPTION
## Summary
- auto-detect repository base path for JSON assets and add cache-busting
- add robust `fetchJSON` / `loadAll` utilities and replace hard-coded URLs
- set `<base href>` in index pages as fallback for relative paths

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`
- `node --check app/app.js`
- `node --check docs/app/app.js`
- `curl -sS http://localhost:8000/factors_namm50.json | jq '.as_of'`
- `curl -sS http://localhost:8000/models/namm50.json | jq '.version'`
- `curl -sS http://localhost:8000/prices.json | jq '.tickers[0].symbol'`


------
https://chatgpt.com/codex/tasks/task_e_6899b6bd84c48333b9bd0f28afe30c27