### PR TITLE
feat: revamp landing to live alpha ui

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,0 +1,188 @@
+/* Anxious Monkey – Live Alpha (vanilla) */
+
+const FACTORS_URL = './factors_namm50.json';
+const MODEL_URL   = './models/namm50.json';
+const PRICES_URL  = './prices.json';
+
+const el = sel => document.querySelector(sel);
+const fmtPct = v => (v == null || Number.isNaN(v)) ? '—' : `${(v*1).toFixed(2)}%`;
+const fmtNum = v => (v == null || Number.isNaN(v)) ? '—' : (Math.abs(v)>=100 ? v.toFixed(0) : v.toFixed(2));
+const toast = (msg) => {
+  const t = el('#toast'); t.textContent = msg; t.classList.remove('hidden');
+  clearTimeout(toast._t); toast._t = setTimeout(()=>t.classList.add('hidden'), 3800);
+};
+
+function last(series){
+  if (!Array.isArray(series) || !series.length) return null;
+  const item = series[series.length-1];
+  // support [ts, value] or [ts, v1, v2]
+  const val = Array.isArray(item) ? item[item.length-1] : null;
+  return (val==null||isNaN(val)) ? null : +val;
+}
+
+function toLine(series, idx=1){ // series:[[ts, v],[...]] or mixed
+  if(!Array.isArray(series)) return {labels:[],data:[]};
+  const labels=[], data=[];
+  for(const row of series){
+    if(!Array.isArray(row)) continue;
+    const ts = row[0];
+    const v  = row[idx] ?? row[row.length-1];
+    if(ts && v!=null && !Number.isNaN(+v)){ labels.push(ts); data.push(+v); }
+  }
+  return {labels,data};
+}
+
+function computeFredSpread(fred){ // prefer 10Y-FF
+  // fred.series columns may be ["DGS10","DFF"] or triplets with name at [0]
+  if(!fred || !Array.isArray(fred.series)) return null;
+  const rows = fred.series;
+  const out = rows.map(r=>{
+    if(Array.isArray(r)){
+      const ts = r[0];
+      // try two-col: [ts, DGS10, DFF]
+      const y10 = r[1]; const ff = r[2];
+      if(ts!=null && y10!=null && ff!=null) return [ts, (+y10) - (+ff)];
+    }
+    return null;
+  }).filter(Boolean);
+  return out;
+}
+
+function makeLine(ctx, labels, data, label){
+  return new Chart(ctx, {
+    type:'line',
+    data:{ labels, datasets:[{
+      label, data, tension:.24, borderWidth:2, pointRadius:0,
+    }]},
+    options:{
+      responsive:true,
+      maintainAspectRatio:false,
+      scales:{
+        x:{ type:'timeseries', ticks:{ color:'#a7b0c0' }, grid:{ color:'#253047' } },
+        y:{ ticks:{ color:'#a7b0c0' }, grid:{ color:'#253047' } }
+      },
+      plugins:{
+        legend:{ display:false },
+        tooltip:{ intersect:false, mode:'index' }
+      }
+    }
+  });
+}
+
+function makeDoughnut(ctx, labels, data){
+  const palette = ['#6ea8fe','#8eecf5','#6be585','#ffcc66'];
+  return new Chart(ctx,{
+    type:'doughnut',
+    data:{ labels, datasets:[{ data, backgroundColor:palette, borderWidth:0 }]},
+    options:{
+      cutout:'62%',
+      plugins:{ legend:{ display:false } }
+    }
+  });
+}
+
+async function fetchJSON(u){
+  const r = await fetch(u, {cache:'no-store'});
+  if(!r.ok) throw new Error(`${r.status} ${r.statusText}`);
+  return r.json();
+}
+
+function setKpi(id, v){ el(id).textContent = (typeof v === 'string') ? v : fmtPct(v); }
+
+function playbookText({naaim,lastNdx50,fredSpread}){
+  // 极简规则：NAAIM>60 & NDX50>50 & spread>0 => Risk-On；反之 Risk-Off；否则 Neutral
+  if(naaim!=null && naaim>60 && lastNdx50!=null && lastNdx50>50 && fredSpread!=null && fredSpread>0){
+    return "Playbook: Risk-On ↗︎  • 提高 beta，顺势持有；若次日回撤<1.2% 继续持有。";
+  }
+  if(naaim!=null && naaim<30 && lastNdx50!=null && lastNdx50<40 && fredSpread!=null && fredSpread<=0){
+    return "Playbook: Risk-Off ↘︎  • 降低仓位，必要时对冲；关注利率与流动性收紧信号。";
+  }
+  return "Playbook: Neutral  • 观望为主；仅在强信号共振时加减仓，保持中性敞口。";
+}
+
+async function main(){
+  const nowStr = new Date().toLocaleString();
+  el('#lastUpdated').textContent = nowStr;
+
+  let factors=null, model=null, prices=null;
+  try{ factors = await fetchJSON(FACTORS_URL); }catch(e){ toast(`加载 factors 失败：${e.message}`); }
+  try{ model   = await fetchJSON(MODEL_URL);   }catch(e){ toast(`加载 model 失败：${e.message}`); }
+  try{ prices  = await fetchJSON(PRICES_URL);  }catch(e){ /* 价格可能未部署，不提示 */ }
+
+  // KPI & charts
+  // ----- weights
+  if(model && model.weights){
+    const labels = Object.keys(model.weights);
+    const data   = labels.map(k=>+model.weights[k] || 0);
+    const wctx = el('#weightsChart').getContext('2d');
+    makeDoughnut(wctx, labels, data);
+    el('#weightsLegend').innerHTML = labels.map((k,i)=>(
+      `<span class="item"><span class="sw" style="background:var(--c${i})"></span>${k}: ${fmtPct(data[i]*100)}</span>`
+    )).join('');
+  }
+
+  // ----- factors
+  let naaimSeries, ndxSeries, chinaSeries, fredSeries;
+  if(factors && factors.factors){
+    naaimSeries = factors.factors.naaim_exposure?.series || null;
+    ndxSeries   = factors.factors.ndx_breadth?.series   || null;
+    chinaSeries = factors.factors.china_proxy?.series   || null;
+    fredSeries  = factors.factors.fred_macro?.series    || null;
+
+    // KPIs
+    setKpi('#kpiNaaim', last(naaimSeries));
+    setKpi('#kpiNdx50', last(ndxSeries));
+    setKpi('#kpiChina', last(chinaSeries));
+    const fredSpreadSeries = computeFredSpread({series: fredSeries});
+    setKpi('#kpiFred', last(fredSpreadSeries));
+
+    // charts
+    if(naaimSeries){
+      const {labels,data} = toLine(naaimSeries);
+      makeLine(el('#naaimChart'), labels, data, 'NAAIM');
+    }
+    if(ndxSeries){
+      const {labels,data} = toLine(ndxSeries);
+      makeLine(el('#ndxChart'), labels, data, '>50DMA');
+    }
+    if(chinaSeries){
+      const {labels,data} = toLine(chinaSeries);
+      makeLine(el('#chinaChart'), labels, data, 'FXI Proxy');
+    }
+    if(fredSpreadSeries){
+      const {labels,data} = toLine(fredSpreadSeries);
+      makeLine(el('#fredChart'), labels, data, '10Y − FF');
+    }
+
+    // Playbook
+    const pb = playbookText({
+      naaim: last(naaimSeries),
+      lastNdx50: last(ndxSeries),
+      fredSpread: last(computeFredSpread({series: fredSeries}))
+    });
+    el('#playbook').innerHTML = `<p>${pb}</p>`;
+  } else {
+    el('#playbook').innerHTML = `<p>数据暂不可用。请稍后刷新或检查发布工作流。</p>`;
+  }
+
+  // ----- Spot price (QQQ / SPY)
+  if(prices && prices.prices){
+    const sym = prices.prices.QQQ ? 'QQQ' : (prices.prices.SPY ? 'SPY' : null);
+    if(sym){
+      const {labels,data} = toLine(prices.prices[sym]);
+      makeLine(el('#spotChart'), labels, data, sym);
+    }
+  }
+
+  // updated time from any文件
+  const asOf = factors?.as_of || model?.as_of || prices?.as_of;
+  if(asOf) el('#lastUpdated').textContent = new Date(asOf).toLocaleString();
+}
+
+el('#refreshBtn').addEventListener('click', ()=>{
+  el('#toast').classList.add('hidden');
+  main().catch(e=>toast(e.message));
+});
+
+// 首次
+main().catch(e=>toast(e.message));

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,1 +1,106 @@
-<!doctype html><meta http-equiv="refresh" content="0; url=./app/"><title>Redirect…</title>
+<!doctype html>
+<html lang="en" class="no-js">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Anxious Monkey — Live Alpha</title>
+  <meta name="color-scheme" content="dark">
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+  <link rel="stylesheet" href="./styles.css" />
+  <!-- Chart.js + time adapter (Luxon) -->
+  <script src="https://cdn.jsdelivr.net/npm/luxon@3.5.0/build/global/luxon.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@1.3.1/dist/chartjs-adapter-luxon.umd.min.js"></script>
+</head>
+<body>
+  <div class="page">
+    <header class="topbar glass">
+      <div class="brand">
+        <span class="dot"></span>
+        <h1>Anxious Monkey <span class="sub">– Live</span></h1>
+      </div>
+      <div class="actions">
+        <div class="updated">
+          <span>Last updated</span>
+          <strong id="lastUpdated">—</strong>
+        </div>
+        <button id="refreshBtn" class="btn">Refresh</button>
+      </div>
+    </header>
+
+    <!-- KPI row -->
+    <section class="kpis">
+      <div class="kpi glass">
+        <div class="kpi-h">NAAIM</div>
+        <div class="kpi-v" id="kpiNaaim">—</div>
+      </div>
+      <div class="kpi glass">
+        <div class="kpi-h">&gt;50DMA (NDX)</div>
+        <div class="kpi-v" id="kpiNdx50">—</div>
+      </div>
+      <div class="kpi glass">
+        <div class="kpi-h">China (FXI)</div>
+        <div class="kpi-v" id="kpiChina">—</div>
+      </div>
+      <div class="kpi glass">
+        <div class="kpi-h">FRED Macro</div>
+        <div class="kpi-v" id="kpiFred">—</div>
+      </div>
+    </section>
+
+    <!-- Grid -->
+    <main class="grid">
+      <section class="card glass">
+        <div class="card-h">Factor Weights</div>
+        <div class="card-b">
+          <canvas id="weightsChart" height="160"></canvas>
+          <div class="legend" id="weightsLegend"></div>
+        </div>
+      </section>
+
+      <section class="card glass">
+        <div class="card-h">Playbook</div>
+        <div class="card-b">
+          <div id="playbook" class="playbook">
+            <div class="skeleton lines"></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="card glass">
+        <div class="card-h">NAAIM Exposure</div>
+        <div class="card-b"><canvas id="naaimChart" height="160"></canvas></div>
+      </section>
+
+      <section class="card glass">
+        <div class="card-h">&gt;50DMA Breadth (NDX)</div>
+        <div class="card-b"><canvas id="ndxChart" height="160"></canvas></div>
+      </section>
+
+      <section class="card glass">
+        <div class="card-h">China Proxy (FXI)</div>
+        <div class="card-b"><canvas id="chinaChart" height="160"></canvas></div>
+      </section>
+
+      <section class="card glass">
+        <div class="card-h">FRED Macro (10Y − FF)</div>
+        <div class="card-b"><canvas id="fredChart" height="160"></canvas></div>
+      </section>
+
+      <section class="card glass wide">
+        <div class="card-h">Spot</div>
+        <div class="card-b"><canvas id="spotChart" height="180"></canvas></div>
+      </section>
+    </main>
+
+    <footer class="foot">
+      <span>© Anxious Monkey</span>
+      <span><a href="https://github.com/guozhongyan/anxiousmonkey-backtests" target="_blank" rel="noreferrer">Repo</a></span>
+    </footer>
+  </div>
+
+  <div id="toast" class="toast hidden"></div>
+
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,94 @@
+:root{
+  --bg:#0d0f14;
+  --panel:#141823cc;
+  --glass:#141823a6;
+  --text:#e9eef6;
+  --muted:#a7b0c0;
+  --brand:#6ea8fe;
+  --accent:#8eecf5;
+  --good:#6be585;
+  --warn:#ffcc66;
+  --bad:#ff6b6b;
+  --ring: 14px;
+  --c0:#6ea8fe;
+  --c1:#8eecf5;
+  --c2:#6be585;
+  --c3:#ffcc66;
+}
+
+*{box-sizing:border-box}
+html,body{height:100%}
+body{
+  margin:0;
+  color:var(--text);
+  background:
+    radial-gradient(1200px 600px at 90% -10%, #23304a 0%, transparent 60%),
+    radial-gradient(800px 500px at -10% 20%, #1d2a3d 0%, transparent 60%),
+    var(--bg);
+  font: 14px/1.6 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
+}
+
+.page{max-width:1280px;margin:0 auto;padding:24px}
+
+.glass{
+  background:var(--glass);
+  border:1px solid #2a3142;
+  backdrop-filter:saturate(120%) blur(14px);
+  border-radius:18px;
+  box-shadow: 0 10px 30px rgba(0,0,0,.35);
+}
+
+.topbar{
+  padding:14px 16px;
+  display:flex;align-items:center;justify-content:space-between;margin-bottom:18px;
+}
+.brand{display:flex;align-items:center;gap:10px}
+.brand .dot{width:10px;height:10px;border-radius:100%;background:linear-gradient(140deg,var(--accent),var(--brand))}
+.brand h1{font-size:18px;margin:0;font-weight:700}
+.brand .sub{color:var(--muted);font-weight:600}
+.actions{display:flex;align-items:center;gap:12px}
+.updated{display:flex;gap:6px;align-items:center;color:var(--muted)}
+.btn{
+  padding:8px 12px;border-radius:12px;border:1px solid #33405a;background:#1a2334;color:var(--text);
+  cursor:pointer;font-weight:600;transition:.18s ease;box-shadow: inset 0 0 0 0 var(--brand);
+}
+.btn:hover{transform:translateY(-1px);border-color:#446099}
+.btn:active{transform:translateY(0)}
+
+.kpis{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:18px}
+.kpi{padding:14px 16px;min-height:80px;display:flex;flex-direction:column;justify-content:center}
+.kpi-h{color:var(--muted);font-weight:600}
+.kpi-v{font-size:24px;font-weight:800;margin-top:4px}
+
+.grid{
+  display:grid;gap:14px;
+  grid-template-columns:repeat(2,1fr);
+  grid-auto-rows:minmax(220px,auto);
+}
+.card{display:flex;flex-direction:column}
+.card.wide{grid-column:1/-1}
+.card-h{padding:14px 16px;border-bottom:1px solid #2a3142;font-weight:700}
+.card-b{padding:14px 16px}
+
+.legend{display:flex;gap:10px;flex-wrap:wrap;margin-top:10px}
+.legend .item{display:flex;align-items:center;gap:8px;color:var(--muted);font-weight:600}
+.legend .sw{width:10px;height:10px;border-radius:2px}
+
+.playbook{min-height:90px}
+.skeleton{position:relative;overflow:hidden;background:#1a2232;border-radius:10px}
+.skeleton.lines{height:90px}
+.skeleton:after{
+  content:"";position:absolute;inset:0;
+  background:linear-gradient(90deg,transparent, #2b3550 40%, transparent 60%);
+  animation:sh 1.2s infinite;
+}
+@keyframes sh{from{transform:translateX(-100%)} to{transform:translateX(100%)}}
+
+.foot{display:flex;justify-content:space-between;gap:10px;color:var(--muted);padding:18px 6px}
+
+.toast{
+  position:fixed;left:50%;bottom:24px;transform:translateX(-50%);
+  padding:10px 14px;border-radius:12px;background:#262f45;color:var(--text);
+  border:1px solid #3a4563;box-shadow:0 8px 24px rgba(0,0,0,.4);max-width:80%;
+}
+.hidden{display:none}


### PR DESCRIPTION
## Summary
- implement Live Alpha UI with KPIs, factor weights, playbook and charts
- add dark glassmorphic theme with responsive layout
- wire vanilla JS to fetch data and render Chart.js visualizations

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: ImportError while importing test module '/workspace/anxiousmonkey-backtests/__init__.py')*


------
https://chatgpt.com/codex/tasks/task_e_689b4bd8988c83338b6fb403c5ffadcf